### PR TITLE
Add team section and navigation links

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
                 <a href="#cases" class="hover:text-primary-700">Кейсы</a>
                 <a href="#process" class="hover:text-primary-700">Этапы</a>
                 <a href="#benefits" class="hover:text-primary-700">Преимущества</a>
+                <a href="#team" class="hover:text-primary-700">Команда</a>
                 <a href="#reviews" class="hover:text-primary-700">Отзывы</a>
                 <a href="#contact" class="px-4 py-2 rounded-xl bg-primary-600 text-white hover:bg-primary-700 shadow-soft">Оставить заявку</a>
             </nav>
@@ -62,6 +63,7 @@
             <a href="#cases" class="py-2">Кейсы</a>
             <a href="#process" class="py-2">Этапы</a>
             <a href="#benefits" class="py-2">Преимущества</a>
+            <a href="#team" class="py-2">Команда</a>
             <a href="#reviews" class="py-2">Отзывы</a>
             <a href="#contact" class="py-2">Оставить заявку</a>
         </div>
@@ -227,6 +229,36 @@
     </div>
 </section>
 
+<!-- Team -->
+<section id="team" class="py-20 bg-slate-50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 class="text-3xl font-extrabold">Команда</h2>
+        <p class="mt-4 text-slate-600 max-w-3xl mx-auto">Мы собрали команду специалистов, которые помогают клиентам получать максимум от своих инвестиций в недвижимость.</p>
+        <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
+            <div class="text-center">
+                <img src="assets/team/team-111.jpg" alt="Ангелина" class="mx-auto rounded-full w-40 h-40 object-cover">
+                <h3 class="mt-4 font-semibold">Ангелина</h3>
+                <p class="text-sm text-slate-600">Основатель и арт‑директор</p>
+            </div>
+            <div class="text-center">
+                <img src="assets/team/team-222.jpg" alt="Антон" class="mx-auto rounded-full w-40 h-40 object-cover">
+                <h3 class="mt-4 font-semibold">Антон</h3>
+                <p class="text-sm text-slate-600">Проектный менеджер</p>
+            </div>
+            <div class="text-center">
+                <img src="assets/team/team-333.jpg" alt="Светлана" class="mx-auto rounded-full w-40 h-40 object-cover">
+                <h3 class="mt-4 font-semibold">Светлана</h3>
+                <p class="text-sm text-slate-600">Дизайнер интерьера</p>
+            </div>
+            <div class="text-center">
+                <img src="assets/team/team-444.jpg" alt="Наталья" class="mx-auto rounded-full w-40 h-40 object-cover">
+                <h3 class="mt-4 font-semibold">Наталья</h3>
+                <p class="text-sm text-slate-600">Специалист по работе с клиентами</p>
+            </div>
+        </div>
+    </div>
+</section>
+
 <!-- Reviews -->
 <section id="reviews" class="py-20">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -310,6 +342,7 @@
                 <li><a href="#services" class="hover:text-primary-700">Услуги</a></li>
                 <li><a href="#cases" class="hover:text-primary-700">Кейсы</a></li>
                 <li><a href="#process" class="hover:text-primary-700">Этапы</a></li>
+                <li><a href="#team" class="hover:text-primary-700">Команда</a></li>
                 <li><a href="#contact" class="hover:text-primary-700">Контакты</a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- add new Team section featuring photos and roles
- link Team section from header, mobile menu, and footer navigation

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c521b8a5e48326908a691c1ac5bb60