### PR TITLE
Improve hero layout and team section alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,19 +71,16 @@
 </header>
 
 <!-- Hero -->
-<section class="relative isolate overflow-hidden bg-slate-50">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32 grid lg:grid-cols-2 gap-12 items-center">
-        <div>
+<section class="relative min-h-[calc(100vh-4rem)] bg-cover bg-center" style="background-image: url('https://images.unsplash.com/photo-1600585154526-990dcedb5dfc?q=80&w=1600&auto=format&fit=crop');">
+    <div class="absolute inset-0 bg-white/70"></div>
+    <div class="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-full flex items-center">
+        <div class="max-w-xl">
             <h1 class="font-serif text-4xl sm:text-5xl font-extrabold leading-tight">Инвест‑дизайн, который увеличивает доходность</h1>
             <p class="mt-6 text-lg text-slate-600">Мы подготавливаем недвижимость к продаже и аренде так, чтобы она выделялась на рынке и приносила больше прибыли. Фокусируемся на сроках сделки и росте стоимости.</p>
             <div class="mt-8 flex flex-wrap gap-4">
                 <a href="#contact" class="px-6 py-3 rounded-xl bg-primary-600 text-white hover:bg-primary-700 shadow-soft">Рассчитать стоимость</a>
                 <a href="#cases" class="px-6 py-3 rounded-xl border border-slate-300 hover:border-primary-600 hover:text-primary-700">Посмотреть кейсы</a>
             </div>
-        </div>
-        <div class="rounded-2xl overflow-hidden shadow-soft">
-            <!-- Hero image (Unsplash) -->
-            <img src="https://images.unsplash.com/photo-1600585154526-990dcedb5dfc?q=80&w=1600&auto=format&fit=crop" alt="Современный интерьер гостиной" class="w-full h-full object-cover">
         </div>
     </div>
 </section>
@@ -230,10 +227,10 @@
 </section>
 
 <!-- Team -->
-<section id="team" class="py-20 bg-slate-50">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+<section id="team" class="py-20 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl font-extrabold">Команда</h2>
-        <p class="mt-4 text-slate-600 max-w-3xl mx-auto">Мы собрали команду специалистов, которые помогают клиентам получать максимум от своих инвестиций в недвижимость.</p>
+        <p class="mt-4 text-slate-600 max-w-3xl">Мы собрали команду специалистов, которые помогают клиентам получать максимум от своих инвестиций в недвижимость.</p>
         <div class="mt-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-8">
             <div class="text-center">
                 <img src="assets/team/team-111.jpg" alt="Ангелина" class="mx-auto rounded-full w-40 h-40 object-cover">


### PR DESCRIPTION
## Summary
- Make hero section span the initial viewport with a full background image
- Left-align "Команда" section heading and text

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52356871483269c295ea461354cd8