### PR TITLE
Use Roboto as default font

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Impression Design — Инвест-дизайн и хоум-стейджинг</title>
 
-    <!-- Google Fonts: Inter + Playfair Display (бесплатно, Google Fonts) -->
+    <!-- Google Fonts: Roboto (бесплатный, Google Fonts) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
 
     <!-- TailwindCSS CDN для быстрого прототипа -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -17,8 +17,8 @@
             theme: {
                 extend: {
                     fontFamily: {
-                        sans: ['Inter', 'system-ui', 'Arial'],
-                        serif: ['Playfair Display', 'serif']
+                        sans: ['Roboto', 'system-ui', 'Arial', 'sans-serif'],
+                        serif: ['Roboto', 'system-ui', 'Arial', 'sans-serif']
                     },
                     colors: {
                         default: '#222222',
@@ -346,7 +346,7 @@
         <div>
             <h3 class="font-semibold">Ассеты (сток и шрифты)</h3>
             <ul class="mt-3 space-y-2 text-slate-600">
-                <li>Шрифты: Inter, Playfair Display — Google Fonts (бесплатные лицензии).</li>
+                <li>Шрифты: Roboto — Google Fonts (бесплатная лицензия).</li>
                 <li>Hero: <a class="underline hover:text-primary-700" href="https://unsplash.com/photos/990dcedb5dfc">unsplash.com/photos/990dcedb5dfc</a></li>
                 <li>Кейс 1 (до): <a class="underline hover:text-primary-700" href="https://unsplash.com/photos/ce8a6c25118b">unsplash.com/photos/ce8a6c25118b</a>; (после): <a class="underline hover:text-primary-700" href="https://unsplash.com/photos/be6161a56a0c">unsplash.com/photos/be6161a56a0c</a></li>
                 <li>Кейс 2 (до): <a class="underline hover:text-primary-700" href="https://unsplash.com/photos/17fe4b02d8db">unsplash.com/photos/17fe4b02d8db</a>; (после): <a class="underline hover:text-primary-700" href="https://unsplash.com/photos/04e8f3e447cd">unsplash.com/photos/04e8f3e447cd</a></li>

--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@
 
 body {
   color: var(--color-default);
+  font-family: 'Roboto', sans-serif;
 }
 
 .text-slate-800,


### PR DESCRIPTION
## Summary
- load Roboto from Google Fonts and configure Tailwind to use it for both sans and serif families
- set body font-family to Roboto and update assets list accordingly

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c5621428908326bea3b1655460ec76