### PR TITLE
Fix before-after slider to overlay images without scaling

### DIFF
--- a/distancionny.html
+++ b/distancionny.html
@@ -72,9 +72,7 @@
         <p class="mt-4 text-slate-600">Чертежи и визуализации без сопровождения работ.</p>
         <div class="relative mt-10 overflow-hidden" id="slider-container">
             <img src="https://images.unsplash.com/photo-1494526585095-c41746248156?auto=format&fit=crop&w=1200&q=80" alt="До" class="w-full">
-            <div class="absolute top-0 left-0 h-full overflow-hidden" id="after-image" style="width:50%">
-                <img src="https://images.unsplash.com/photo-1507089947368-19c1da9775ae?auto=format&fit=crop&w=1200&q=80" alt="После" class="w-full">
-            </div>
+            <img src="https://images.unsplash.com/photo-1507089947368-19c1da9775ae?auto=format&fit=crop&w=1200&q=80" alt="После" class="absolute top-0 left-0 w-full h-full object-cover" id="after-image" style="clip-path:polygon(0 0,50% 0,50% 100%,0 100%)">
             <div id="slider-handle" class="absolute top-0 h-full cursor-ew-resize" style="left:50%">
                 <div style="position:absolute;top:0;bottom:0;left:-1px;width:2px;background:white;"></div>
                 <div style="position:absolute;top:50%;left:-12px;width:24px;height:24px;border:2px solid #cbd5e1;background:white;border-radius:50%;transform:translateY(-50%);"></div>
@@ -140,7 +138,7 @@
         const rect = container.getBoundingClientRect();
         let percent = ((x - rect.left) / rect.width) * 100;
         percent = Math.max(0, Math.min(100, percent));
-        after.style.width = percent + '%';
+        after.style.clipPath = `polygon(0 0, ${percent}% 0, ${percent}% 100%, 0 100%)`;
         handle.style.left = percent + '%';
     };
     container.addEventListener('pointerdown', (e) => {

--- a/remont.html
+++ b/remont.html
@@ -72,9 +72,7 @@
         <p class="mt-4 text-slate-600">Дизайн-проект и авторский надзор для ремонта с нуля.</p>
         <div class="relative mt-10 overflow-hidden" id="slider-container">
             <img src="https://images.unsplash.com/photo-1523217582562-09d0d75ce8a1?auto=format&fit=crop&w=1200&q=80" alt="До" class="w-full">
-            <div class="absolute top-0 left-0 h-full overflow-hidden" id="after-image" style="width:50%">
-                <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?auto=format&fit=crop&w=1200&q=80" alt="После" class="w-full">
-            </div>
+            <img src="https://images.unsplash.com/photo-1501183638710-841dd1904471?auto=format&fit=crop&w=1200&q=80" alt="После" class="absolute top-0 left-0 w-full h-full object-cover" id="after-image" style="clip-path:polygon(0 0,50% 0,50% 100%,0 100%)">
             <div id="slider-handle" class="absolute top-0 h-full cursor-ew-resize" style="left:50%">
                 <div style="position:absolute;top:0;bottom:0;left:-1px;width:2px;background:white;"></div>
                 <div style="position:absolute;top:50%;left:-12px;width:24px;height:24px;border:2px solid #cbd5e1;background:white;border-radius:50%;transform:translateY(-50%);"></div>
@@ -140,7 +138,7 @@
         const rect = container.getBoundingClientRect();
         let percent = ((x - rect.left) / rect.width) * 100;
         percent = Math.max(0, Math.min(100, percent));
-        after.style.width = percent + '%';
+        after.style.clipPath = `polygon(0 0, ${percent}% 0, ${percent}% 100%, 0 100%)`;
         handle.style.left = percent + '%';
     };
     container.addEventListener('pointerdown', (e) => {

--- a/upakovka.html
+++ b/upakovka.html
@@ -72,9 +72,7 @@
         <p class="mt-4 text-slate-600">Декор и меблировка без строительных работ.</p>
         <div class="relative mt-10 overflow-hidden" id="slider-container">
             <img src="https://images.unsplash.com/photo-1502672023488-70e25813eb80?auto=format&fit=crop&w=1200&q=80" alt="До" class="w-full">
-            <div class="absolute top-0 left-0 h-full overflow-hidden" id="after-image" style="width:50%">
-                <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80" alt="После" class="w-full">
-            </div>
+            <img src="https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=1200&q=80" alt="После" class="absolute top-0 left-0 w-full h-full object-cover" id="after-image" style="clip-path:polygon(0 0,50% 0,50% 100%,0 100%)">
             <div id="slider-handle" class="absolute top-0 h-full cursor-ew-resize" style="left:50%">
                 <div style="position:absolute;top:0;bottom:0;left:-1px;width:2px;background:white;"></div>
                 <div style="position:absolute;top:50%;left:-12px;width:24px;height:24px;border:2px solid #cbd5e1;background:white;border-radius:50%;transform:translateY(-50%);"></div>
@@ -140,7 +138,7 @@
         const rect = container.getBoundingClientRect();
         let percent = ((x - rect.left) / rect.width) * 100;
         percent = Math.max(0, Math.min(100, percent));
-        after.style.width = percent + '%';
+        after.style.clipPath = `polygon(0 0, ${percent}% 0, ${percent}% 100%, 0 100%)`;
         handle.style.left = percent + '%';
     };
     container.addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
## Summary
- avoid zooming in before-after slider by overlaying images with clip-path
- update slider script to move clip-path instead of resizing images

## Testing
- `npx --yes prettier --check distancionny.html remont.html upakovka.html`

------
https://chatgpt.com/codex/tasks/task_e_68c7237a04088326b7a9fd0820e9688f