### PR TITLE
Remove curator tariff card from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
 <section class="py-20" id="services">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl font-extrabold">Стоимость и услуги</h2>
-        <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
             <article class="service-card">
                 <div class="service-card-header">
                     <span class="service-badge">Онлайн</span>
@@ -319,44 +319,6 @@
                 <div class="service-cta">
                     <a class="service-button service-button--ghost" href="interior-whitebox.html">Подробнее</a>
                     <a class="service-button service-button--primary" href="#contact">Куратор*</a>
-                </div>
-            </article>
-            <article class="service-card">
-                <div class="service-card-header">
-                    <span class="service-badge">Контроль</span>
-                    <span class="service-duration">Дистанционно</span>
-                </div>
-                <h3 class="service-card-title">Куратор проекта</h3>
-                <p class="service-card-lead">Держим подрядчика в фокусе, проверяем отчёты и даём правки, чтобы вы не уходили в переделки и лишние траты.</p>
-                <div class="service-highlights">
-                    <div class="service-feature">
-                        <span class="service-feature-icon" aria-hidden="true">
-                            <svg fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M5 12.5L9 16.5L19 6.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-                            </svg>
-                        </span>
-                        <div>
-                            <p class="service-feature-title">Контроль</p>
-                            <p>Проверка фото/видео-отчётов, чек-листы и точечные правки.</p>
-                        </div>
-                    </div>
-                    <div class="service-feature">
-                        <span class="service-feature-icon" aria-hidden="true">
-                            <svg fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M5 12.5L9 16.5L19 6.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-                            </svg>
-                        </span>
-                        <div>
-                            <p class="service-feature-title">Коммуникации</p>
-                            <p>Работаем в мессенджерах, отвечаем по SLA, фиксируем риски и To-Do.</p>
-                        </div>
-                    </div>
-                </div>
-                <p class="service-note"><span>Формат:</span> пакеты Light, Standard и Pro + аддоны по запросу.</p>
-                <p class="service-price">Стоимость: от 12&nbsp;000&nbsp;₽/мес</p>
-                <div class="service-cta">
-                    <a class="service-button service-button--ghost" href="kurator.html">Подробнее</a>
-                    <a class="service-button service-button--primary" href="#contact">Оставить заявку</a>
                 </div>
             </article>
         </div>


### PR DESCRIPTION
## Summary
- remove the curator tariff card from the homepage services section
- update the services grid to show three columns for the remaining tariffs

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fdce07a883269d7fb6ee5976d633)